### PR TITLE
ci: GitHub Actions で CI を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

- main ブランチへの push と PR をトリガーに typecheck / test / build を自動実行する GitHub Actions ワークフローを追加
- Node.js 22 + npm ci によるキャッシュ付きセットアップ
- ローカルで全ステップの通過を確認済み（71 tests passed）

Closes #6

## Test plan

- [ ] PR の CI が緑になることを確認
- [ ] main マージ後に push トリガーでも CI が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)