### PR TITLE
ci: GitHub Pages へデプロイする

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
+  base: '/mahjong_meetup/',
   plugins: [tailwindcss(), react()],
 });


### PR DESCRIPTION
## Summary

- `deploy.yml` を追加: main push 時に `pnpm run build` → `actions/deploy-pages` で自動デプロイ
- `vite.config.ts` に `base: '/mahjong_meetup/'` を設定し、サブパスでの配信に対応
- `concurrency` で同時デプロイを防止

Closes #11

## マージ後に必要な手動設定

リポジトリの Settings > Pages > Source を **GitHub Actions** に変更する必要があります。

## Test plan

- [x] ローカルで typecheck / test (71 passed) / build 通過を確認
- [x] CI が緑になることを確認
- [ ] マージ後、Settings > Pages を GitHub Actions に設定
- [ ] `https://shunsock.github.io/mahjong_meetup/` でページが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)