### PR TITLE
ci: Dependabot で GitHub Actions のバージョンを自動更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      timezone: Asia/Tokyo


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` を追加
- `github-actions` エコシステムを対象に毎週月曜 (JST) にバージョンチェック
- CI の Node.js 20 deprecation 警告 (`actions/checkout@v4` 等) への対応 PR が自動で作成されるようになる

Closes #15

## Test plan

- [ ] CI が緑になることを確認
- [ ] マージ後、Dependabot が actions のバージョン更新 PR を作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)