### PR TITLE
feat: Taskfile を導入して開発コマンドを統一

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,40 @@
+version: "3"
+
+tasks:
+  dev:
+    desc: Start Vite development server
+    cmd: pnpm dev
+
+  build:
+    desc: TypeScript compile and Vite build
+    deps: [typecheck]
+    cmd: pnpm build
+
+  preview:
+    desc: Preview built app
+    cmd: pnpm preview
+
+  typecheck:
+    desc: Run TypeScript type checking
+    cmd: pnpm typecheck
+
+  test:
+    desc: Run tests once
+    cmd: pnpm test
+
+  test:watch:
+    desc: Run tests in watch mode
+    cmd: pnpm test:watch
+
+  check:
+    desc: Run typecheck and tests
+    deps: [typecheck, test]
+
+  install:
+    desc: Install dependencies
+    cmd: pnpm install
+    sources:
+      - package.json
+      - pnpm-lock.yaml
+    generates:
+      - node_modules/**/*

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,28 +3,28 @@ version: "3"
 tasks:
   dev:
     desc: Start Vite development server
-    cmd: pnpm dev
+    cmd: nix develop -c pnpm run dev
 
   build:
     desc: TypeScript compile and Vite build
     deps: [typecheck]
-    cmd: pnpm build
+    cmd: nix develop -c pnpm run build
 
   preview:
     desc: Preview built app
-    cmd: pnpm preview
+    cmd: nix develop -c pnpm run preview
 
   typecheck:
     desc: Run TypeScript type checking
-    cmd: pnpm typecheck
+    cmd: nix develop -c pnpm run typecheck
 
   test:
     desc: Run tests once
-    cmd: pnpm test
+    cmd: nix develop -c pnpm run test
 
   test:watch:
     desc: Run tests in watch mode
-    cmd: pnpm test:watch
+    cmd: nix develop -c pnpm run test:watch
 
   check:
     desc: Run typecheck and tests
@@ -32,7 +32,7 @@ tasks:
 
   install:
     desc: Install dependencies
-    cmd: pnpm install
+    cmd: nix develop -c pnpm install
     sources:
       - package.json
       - pnpm-lock.yaml

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
           buildInputs = with pkgs; [
             nodejs_22
             pnpm
+            go-task
           ];
 
           shellHook = ''


### PR DESCRIPTION
## Background

このプロジェクトでは開発コマンドが `pnpm dev`, `pnpm typecheck`, `pnpm test` など package.json の scripts に定義されている。これは動作上問題ないが、いくつかの不便さがある:

- typecheck とテストを並列実行する手段がなく、毎回手動で2回コマンドを叩く必要がある
- `build` の前に `typecheck` を自動実行するといった依存関係の定義が package.json scripts では表現しにくい
- `pnpm install` の不要な再実行を防ぐ（ソースファイルが変更されていなければスキップする）仕組みがない

go-task (Taskfile) を導入し、これらの問題を解決する。

## Approach

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: go-task (Taskfile) | タスク間依存・並列実行・ソース変更検知を宣言的に記述可能。YAML で可読性が高い | 新しいツールの追加 |
| B: Makefile | 追加ツール不要。広く知られている | YAML に比べ可読性が低い。タブ必須の構文が扱いづらい |
| C: just | シンプルで使いやすい | タスク間依存やソース変更検知の機能が限定的 |

### 採用理由

go-task はタスク間の `deps` による依存関係定義、`sources`/`generates` によるキャッシュ、タスクの並列実行を宣言的な YAML で記述できる。プロジェクトの Nix devShell にも `pkgs.go-task` として簡単に追加できるため、再現可能な開発環境との相性が良い。

## What Changed

### Taskfile の追加

- `Taskfile.yml` - 以下のタスクを定義:
  - `dev`, `build`, `preview`, `typecheck`, `test`, `test:watch`: pnpm スクリプトのラッパー
  - `check`: typecheck と test を並列実行する複合タスク
  - `install`: `sources`/`generates` によりロックファイル未変更時はスキップ
  - `build` は `deps: [typecheck]` で型チェック通過後にのみビルドを実行

### devShell への go-task 追加

- `flake.nix` - `buildInputs` に `go-task` を追加

## Tradeoffs and Limitations

- **pnpm scripts との二重管理**: Taskfile は pnpm scripts をラップしているため、コマンド定義が2箇所に存在する。ただし Taskfile 側が「どう実行するか」、package.json 側が「何を実行するか」という役割分担であり、実質的に矛盾は生じない
- **go-task への依存追加**: Nix devShell に閉じているため、CI やデプロイへの影響はない

## Testing

- `task --list` で全タスクが正しく登録されていることを確認
- `task check` で typecheck・テストが並列実行され、全71テストがパスすることを確認

## Review Guide

1. `Taskfile.yml` — タスク定義の全体像を確認してください。特に `build` の `deps` と `install` の `sources`/`generates` が意図通りか
2. `flake.nix` — 1行追加のみ。`go-task` パッケージの追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)