### PR TITLE
refactor: usecase/adapter 骨組みの新設と状態 Port 確立

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -5,7 +5,8 @@
 ```
 src/
 ├── domain/          # ドメインロジック (純粋関数・値オブジェクト)
-├── state/           # アプリケーション状態管理 (React hooks)
+├── usecase/         # アプリケーションのビジネスフローと外部依存の抽象 (Port)
+├── adapter/         # usecase の Port の実装 (React hooks 等)
 ├── presentation/    # UI コンポーネント
 │   ├── controls/    # 入力系コンポーネント
 │   └── dialogs/     # ダイアログコンポーネント
@@ -18,10 +19,11 @@ src/
 | レイヤー | 責務 | 依存先 |
 |---------|------|--------|
 | `domain` | 点数計算・スコアボード等のビジネスロジック。フレームワーク非依存 | なし |
-| `state` | `domain` を使ってアプリの状態遷移を管理する React hooks | `domain` |
-| `presentation` | 画面表示とユーザー操作のハンドリング | `domain`, `state` |
+| `usecase` | `domain` を使ったアプリケーションのビジネスフロー (action) と、状態操作等の外部依存を抽象化する Port | `domain` |
+| `adapter` | `usecase` の Port を実装する具体的な手段 (React hooks 等) | `domain`, `usecase` |
+| `presentation` | 画面表示とユーザー操作のハンドリング | `domain`, `usecase`, `adapter` |
 
-依存方向は `presentation` → `state` → `domain` の一方向です。`domain` は他のレイヤーに依存しません。
+依存方向は `presentation` → `usecase` / `adapter` → `domain` の一方向です。`domain` は他のレイヤーに依存しません。`adapter` は `usecase` が定義する Port を実装する形で依存します。
 
 ## コマンド一覧
 
@@ -64,7 +66,7 @@ nix develop -c pnpm run vitest run src/domain/scoreboard.test.ts
 - **不変データ**: ドメインオブジェクトは immutable。状態の変更は新しいオブジェクトを生成して行う
 - **純粋関数**: `domain` レイヤーは副作用を持たない純粋関数で構成する
 - **型安全**: `NaturalNumber` 等の値オブジェクトで不正な状態を型レベルで防止する
-- **一方向依存**: `presentation` → `state` → `domain` の依存方向を守る
+- **一方向依存**: `presentation` → `usecase` / `adapter` → `domain` の依存方向を守る
 
 ## CI
 

--- a/src/adapter/state/game-state-adapter.ts
+++ b/src/adapter/state/game-state-adapter.ts
@@ -1,5 +1,5 @@
 /**
- * ゲーム状態の管理 (useReducer による glue 層)。
+ * GameStatePort の useReducer 実装 (adapter)。
  *
  * 状態は { initial, history } の 2 つだけで、現在の Scoreboard は
  * replay によって derive される。
@@ -8,20 +8,21 @@
  */
 
 import { useMemo, useReducer } from 'react';
-import type { Player } from '../domain/player';
-import type { ScoreMovement } from '../domain/movement';
+import type { Player } from '../../domain/player';
+import type { ScoreMovement } from '../../domain/movement';
 import {
   createInitialScoreboard,
   replay,
   type Scoreboard,
-} from '../domain/scoreboard';
+} from '../../domain/scoreboard';
+import type { GameStatePort } from '../../usecase/game/port';
 
-export type GameState = Readonly<{
+type GameState = Readonly<{
   initial: Scoreboard;
   history: ReadonlyArray<ScoreMovement>;
 }>;
 
-export type GameAction =
+type GameAction =
   | Readonly<{ type: 'dispatch'; movement: ScoreMovement }>
   | Readonly<{ type: 'undo' }>
   | Readonly<{ type: 'reset'; players: ReadonlyArray<Player> }>;
@@ -41,17 +42,9 @@ const reducer = (state: GameState, action: GameAction): GameState => {
   }
 };
 
-export type UseGameStateResult = Readonly<{
-  board: Scoreboard;
-  canUndo: boolean;
-  dispatch: (movement: ScoreMovement) => void;
-  undo: () => void;
-  reset: (players: ReadonlyArray<Player>) => void;
-}>;
-
-export const useGameState = (
+export const useGameStateAdapter = (
   players: ReadonlyArray<Player>,
-): UseGameStateResult => {
+): GameStatePort => {
   const [state, dispatchAction] = useReducer(
     reducer,
     players,

--- a/src/presentation/Dashboard.tsx
+++ b/src/presentation/Dashboard.tsx
@@ -4,7 +4,7 @@ import { RotateCcw, LogOut } from 'lucide-react';
 import type { Player, PlayerId } from '../domain/player';
 import type { Scoreboard } from '../domain/scoreboard';
 import type { ScoreMovement } from '../domain/movement';
-import { useGameState } from '../state/useGameState';
+import { useGameStateAdapter } from '../adapter/state/game-state-adapter';
 import { PlayerCard } from './PlayerCard';
 import { RonDialog } from './dialogs/RonDialog';
 import { TsumoDialog } from './dialogs/TsumoDialog';
@@ -57,7 +57,7 @@ const rankPlayers = (board: Scoreboard): ReadonlyArray<RankedPlayer> => {
 };
 
 export const Dashboard = ({ players, onReset, onEndMatch }: Props) => {
-  const { board, canUndo, dispatch, undo, reset } = useGameState(players);
+  const { board, canUndo, dispatch, undo, reset } = useGameStateAdapter(players);
   const [dialog, setDialog] = useState<DialogKind>(null);
 
   const ranked = rankPlayers(board);

--- a/src/usecase/game/port.ts
+++ b/src/usecase/game/port.ts
@@ -1,0 +1,19 @@
+import type { Player } from '../../domain/player';
+import type { ScoreMovement } from '../../domain/movement';
+import type { Scoreboard } from '../../domain/scoreboard';
+
+/**
+ * ゲーム状態操作の Port。
+ *
+ * usecase 層が「状態をどう保持し、どう変更するか」という実装詳細
+ * (React の useReducer なのか、別の状態管理手段なのか) を知らずに
+ * 済むようにするための抽象境界。adapter 層 (例:
+ * useGameStateAdapter) がこの Port を実装する。
+ */
+export type GameStatePort = Readonly<{
+  board: Scoreboard;
+  canUndo: boolean;
+  dispatch: (movement: ScoreMovement) => void;
+  undo: () => void;
+  reset: (players: ReadonlyArray<Player>) => void;
+}>;


### PR DESCRIPTION
## 概要

- clean architecture 再編 (#54) の最初の一歩として、usecase 層と adapter 層の骨組みを新設した。
- 状態操作の抽象 `GameStatePort` を定義し、既存の useReducer フックをその実装 (adapter) に位置づけ直した。

Closes #55

## 背景

- 親 Issue #54 で、UI 4 階層 + usecase 層への段階的な再編と、その依存方向 (`presentation` → `usecase` → `adapter` → `domain`) が確定した。
- 現状は `src/state/useGameState.ts` が domain と UI を直結する唯一の glue であり、usecase 層と Port/Adapter の抽象が存在しなかった。
- 後続サブイシュー (#56〜#61) が画面単位の移行を進めるため、先に依存の骨格だけを確立する必要があった。

## 課題

状態管理の実装詳細 (useReducer) に UI が直接依存しており、後続の画面移行で usecase action を差し込む土台がなかった。骨組みなしに画面移行を始めると、各 PR が抽象の設計判断を個別に抱え込み、レイヤー境界がぶれる。

## 目標

### 必須項目

- `GameStatePort` (board / canUndo / dispatch / undo / reset) を usecase 層に定義する
- 既存フックを adapter として再配置し、`GameStatePort` を実装する形にする
- 全画面の挙動・reducer ロジックを一切変えない
- typecheck / 既存 71 テスト / build がすべて通る

### 範囲外

- 各画面の 4 層分割 (SetupScreen は #56、Dashboard は #57、ResultScreen は #60)
- usecase action の実装 (dispatch-movement 等は #57 以降)
- localStorage 永続化・状態管理ライブラリの導入 (親 Issue のスコープ外)

## 採用手法

Port を usecase 層に置き、実装 (adapter) を外側の層に置く依存性逆転の形をとった。usecase はこれから書かれる action 群の置き場所であり、action が `GameStatePort` にのみ依存することで、状態管理の実装詳細 (useReducer か、将来の別手段か) から独立する。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: Port を usecase 層に定義し、既存フックを adapter として移動 (採用) | 依存方向が親 Issue の設計どおりに確立する。ロジック無変更で安全 | 実装が 1 つしかない抽象を先行して導入する (現時点では冗長に見える) |
| B: 骨組みを作らず #56 以降の画面移行 PR で必要になった時点で導入 | 先行投資がない | 各画面 PR が抽象の設計判断を個別に抱え、境界がぶれるリスクがある |

### 採用理由

親 Issue #54 のヒアリングで「Port/Adapter 構造の確立自体が目的」と確定しているため、抽象の先行導入は投機ではなく要求である。ロジックを変えない移動とリネームだけで骨格を固定できるため、リスクが最小の時点で実施した。

```mermaid
flowchart LR
  Dashboard["presentation/Dashboard.tsx"] --> Adapter["adapter/state/game-state-adapter.ts<br/>useGameStateAdapter"]
  Adapter -. implements .-> Port["usecase/game/port.ts<br/>GameStatePort"]
  Adapter --> Domain["domain/scoreboard.ts<br/>createInitialScoreboard / replay"]
```

## 変更箇所

- `src/usecase/game/port.ts`: `GameStatePort` (状態操作の抽象) を新設
- `src/state/useGameState.ts` → `src/adapter/state/game-state-adapter.ts`: 移動し、`useGameState` を `useGameStateAdapter` にリネームして戻り値型を `GameStatePort` に変更 (reducer 本体は無変更)。あわせてモジュール外で未使用だった `GameState` / `GameAction` の export を外し module-private 化
- `src/presentation/Dashboard.tsx`: import と呼び出しを新 adapter へ差し替え (2 行)
- `docs/develop.md`: レイヤー構成・依存方向を `usecase` / `adapter` を含む形に更新

## 妥協と制限

- **手動回帰確認は後続 PR とまとめて実施**: UI テスト基盤が未導入のため画面操作の自動検証はない。本 PR はロジック無変更 (diff で reducer 不変を確認) であり、typecheck / 71 テスト / build を代替の裏付けとした。全画面の手動回帰は #61 のチェックリストで実施する
- **Dashboard.tsx の複雑度 (32.2) は未解消**: 本 PR の対象外であり、#57 の 4 層分割で解消する

## 検証方法

- `nix develop -c pnpm run typecheck` — `useGameStateAdapter` の `GameStatePort` 適合を型で検証
- `nix develop -c pnpm test` — 既存 domain テスト 5 ファイル 71 件全パス
- `nix develop -c pnpm run build` — import パス破損がないことを確認
- 旧フック名 `useGameState`・旧パス `state/useGameState` の残存参照が 0 件であることを grep で確認
- 認知的複雑度: adapter 10.55 → 9.98 (改善)、Dashboard 32.23 → 32.23 (無変化)

## 確認事項

- ⚠️ `GameStatePort` のメンバー構成 (board / canUndo / dispatch / undo / reset) を現行フックの返却値そのままとした。#57 で usecase action を導入する際の分割単位に影響するため、この粒度で問題ないか確認してほしい
- ⚠️ docs/develop.md は暫定更新であり、presentation の 4 階層 (screen/layout/container/component) は #61 で最終化する

## 参考文献

- [#55 usecase/adapter 骨組みの新設と状態 Port 確立](https://github.com/shunsock/mahjong_meetup/issues/55)
- [#54 presentation 層を clean architecture 4 階層 + usecase 層へ再編する](https://github.com/shunsock/mahjong_meetup/issues/54)
- [The Clean Architecture (Robert C. Martin)](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)
