### PR TITLE
refactor: Ron/Tsumo の点数プレビューと本場カウンタを usecase 化する

### DIFF
--- a/src/presentation/component/dialogs/RonDialog.tsx
+++ b/src/presentation/component/dialogs/RonDialog.tsx
@@ -1,44 +1,56 @@
 import { useState, useMemo } from 'react';
-import type { Player, PlayerId } from '../../domain/player';
-import type { ScoreMovement } from '../../domain/movement';
-import { calcKoRon, calcOyaRon } from '../../domain/score-calculation';
-import { Modal } from '../component/dialogs/Modal';
-import { PlayerSelector } from '../component/controls/PlayerSelector';
-import { HanFuInput } from '../component/controls/HanFuInput';
-import { CounterInput } from '../component/controls/CounterInput';
-import { NaturalNumber } from '../../domain/natural-number';
+import type { Player, PlayerId } from '../../../domain/player';
+import type { ScoreMovement } from '../../../domain/movement';
+import type { NaturalNumber } from '../../../domain/natural-number';
+import { Modal } from './Modal';
+import { PlayerSelector } from '../controls/PlayerSelector';
+import { HanFuInput } from '../controls/HanFuInput';
+import { CounterInput } from '../controls/CounterInput';
+
+type Mode = 'ko' | 'oya';
 
 type Props = Readonly<{
   players: ReadonlyArray<Player>;
   onConfirm: (movement: ScoreMovement) => void;
   onCancel: () => void;
+  onCalculateScore: (mode: Mode, han: number | null, fu: number | null) => number | null;
+  onIncrementHonba: (current: NaturalNumber) => NaturalNumber;
+  onDecrementHonba: (current: NaturalNumber) => NaturalNumber;
+  onResetHonba: () => NaturalNumber;
 }>;
-
-type Mode = 'ko' | 'oya';
 
 /**
  * ロン入力ダイアログ。
  * 和了者・放銃者・翻/符 (子/親切替) を入力し、点数を自動算出する。
+ * 点数算出・本場カウンタの操作は props 経由で usecase 層に委譲する。
  */
-export const RonDialog = ({ players, onConfirm, onCancel }: Props) => {
+export const RonDialog = ({
+  players,
+  onConfirm,
+  onCancel,
+  onCalculateScore,
+  onIncrementHonba,
+  onDecrementHonba,
+  onResetHonba,
+}: Props) => {
   const [winner, setWinner] = useState<PlayerId | null>(null);
   const [loser, setLoser] = useState<PlayerId | null>(null);
   const [mode, setMode] = useState<Mode>('ko');
   const [han, setHan] = useState<number | null>(null);
   const [fu, setFu] = useState<number | null>(null);
-  const [honba, setHonba] = useState(NaturalNumber.of(0));
+  const [honba, setHonba] = useState<NaturalNumber>(onResetHonba);
 
-  const score = useMemo(() => {
-    if (han === null || fu === null) return null;
-    return mode === 'ko' ? calcKoRon(han, fu) : calcOyaRon(han, fu);
-  }, [han, fu, mode]);
+  const score = useMemo(
+    () => onCalculateScore(mode, han, fu),
+    [han, fu, mode, onCalculateScore],
+  );
 
   const canConfirm =
     winner !== null && loser !== null && score !== null;
 
   const handleConfirm = () => {
     if (!canConfirm || score === null) return;
-    onConfirm({ kind: 'ron', winner, loser, amount: score.total, honba });
+    onConfirm({ kind: 'ron', winner, loser, amount: score, honba });
   };
 
   return (
@@ -84,15 +96,15 @@ export const RonDialog = ({ players, onConfirm, onCancel }: Props) => {
           fu={fu}
           onHanSelect={setHan}
           onFuSelect={setFu}
-          calculatedScore={score?.total ?? null}
+          calculatedScore={score}
         />
 
         <CounterInput
           label="本場"
           value={honba}
-          onIncrement={() => setHonba(NaturalNumber.of(honba + 1))}
-          onDecrement={() => setHonba(NaturalNumber.of(Math.max(0, honba - 1)))}
-          onReset={() => setHonba(NaturalNumber.of(0))}
+          onIncrement={() => setHonba(onIncrementHonba(honba))}
+          onDecrement={() => setHonba(onDecrementHonba(honba))}
+          onReset={() => setHonba(onResetHonba())}
         />
       </div>
     </Modal>

--- a/src/presentation/component/dialogs/TsumoDialog.tsx
+++ b/src/presentation/component/dialogs/TsumoDialog.tsx
@@ -1,39 +1,51 @@
 import { useState, useMemo } from 'react';
-import type { Player, PlayerId } from '../../domain/player';
-import type { ScoreMovement } from '../../domain/movement';
-import { calcKoTsumo, calcOyaTsumo } from '../../domain/score-calculation';
-import { Modal } from '../component/dialogs/Modal';
-import { PlayerSelector } from '../component/controls/PlayerSelector';
-import { HanFuInput } from '../component/controls/HanFuInput';
-import { CounterInput } from '../component/controls/CounterInput';
-import { NaturalNumber } from '../../domain/natural-number';
+import type { Player, PlayerId } from '../../../domain/player';
+import type { ScoreMovement } from '../../../domain/movement';
+import type { NaturalNumber } from '../../../domain/natural-number';
+import { Modal } from './Modal';
+import { PlayerSelector } from '../controls/PlayerSelector';
+import { HanFuInput } from '../controls/HanFuInput';
+import { CounterInput } from '../controls/CounterInput';
+
+type Mode = 'ko' | 'oya';
 
 type Props = Readonly<{
   players: ReadonlyArray<Player>;
   onConfirm: (movement: ScoreMovement) => void;
   onCancel: () => void;
+  onCalculateScore: (mode: Mode, han: number | null, fu: number | null) => number | null;
+  onIncrementHonba: (current: NaturalNumber) => NaturalNumber;
+  onDecrementHonba: (current: NaturalNumber) => NaturalNumber;
+  onResetHonba: () => NaturalNumber;
 }>;
-
-type Mode = 'ko' | 'oya';
 
 /**
  * ツモ入力ダイアログ。
  * 翻/符から点数を自動算出する。
  * 子ツモの場合は「和了者」と「親」を別々に選ぶ必要がある。
  * 親ツモの場合は和了者 = 親なので親選択 UI は出さない。
+ * 点数算出・本場カウンタの操作は props 経由で usecase 層に委譲する。
  */
-export const TsumoDialog = ({ players, onConfirm, onCancel }: Props) => {
+export const TsumoDialog = ({
+  players,
+  onConfirm,
+  onCancel,
+  onCalculateScore,
+  onIncrementHonba,
+  onDecrementHonba,
+  onResetHonba,
+}: Props) => {
   const [mode, setMode] = useState<Mode>('ko');
   const [winner, setWinner] = useState<PlayerId | null>(null);
   const [dealer, setDealer] = useState<PlayerId | null>(null);
   const [han, setHan] = useState<number | null>(null);
   const [fu, setFu] = useState<number | null>(null);
-  const [honba, setHonba] = useState(NaturalNumber.of(0));
+  const [honba, setHonba] = useState<NaturalNumber>(onResetHonba);
 
-  const score = useMemo(() => {
-    if (han === null || fu === null) return null;
-    return mode === 'ko' ? calcKoTsumo(han, fu) : calcOyaTsumo(han, fu);
-  }, [han, fu, mode]);
+  const score = useMemo(
+    () => onCalculateScore(mode, han, fu),
+    [han, fu, mode, onCalculateScore],
+  );
 
   const canConfirm =
     winner !== null &&
@@ -43,10 +55,10 @@ export const TsumoDialog = ({ players, onConfirm, onCancel }: Props) => {
   const handleConfirm = () => {
     if (!canConfirm || score === null) return;
     if (mode === 'oya') {
-      onConfirm({ kind: 'tsumo-oya', winner, total: score.total, honba });
+      onConfirm({ kind: 'tsumo-oya', winner, total: score, honba });
     } else {
       if (dealer === null) return;
-      onConfirm({ kind: 'tsumo-ko', winner, dealer, total: score.total, honba });
+      onConfirm({ kind: 'tsumo-ko', winner, dealer, total: score, honba });
     }
   };
 
@@ -105,15 +117,15 @@ export const TsumoDialog = ({ players, onConfirm, onCancel }: Props) => {
           fu={fu}
           onHanSelect={setHan}
           onFuSelect={setFu}
-          calculatedScore={score?.total ?? null}
+          calculatedScore={score}
         />
 
         <CounterInput
           label="本場"
           value={honba}
-          onIncrement={() => setHonba(NaturalNumber.of(honba + 1))}
-          onDecrement={() => setHonba(NaturalNumber.of(Math.max(0, honba - 1)))}
-          onReset={() => setHonba(NaturalNumber.of(0))}
+          onIncrement={() => setHonba(onIncrementHonba(honba))}
+          onDecrement={() => setHonba(onDecrementHonba(honba))}
+          onReset={() => setHonba(onResetHonba())}
         />
       </div>
     </Modal>

--- a/src/presentation/container/DashboardContainer.tsx
+++ b/src/presentation/container/DashboardContainer.tsx
@@ -7,6 +7,13 @@ import { dispatchMovement } from '../../usecase/game/dispatch-movement';
 import { undoMovement } from '../../usecase/game/undo-movement';
 import { resetMatch } from '../../usecase/game/reset-match';
 import { rankStandings } from '../../usecase/game/rank-standings';
+import { calculateRonScore } from '../../usecase/game/calculate-ron-score';
+import { calculateTsumoScore } from '../../usecase/game/calculate-tsumo-score';
+import {
+  incrementHonba,
+  decrementHonba,
+  resetHonba,
+} from '../../usecase/game/adjust-honba';
 import { DashboardLayout } from '../layout/DashboardLayout';
 import type { DialogKind } from '../layout/DashboardLayout';
 
@@ -53,6 +60,15 @@ export const DashboardContainer = ({ players, onReset, onEndMatch }: Props) => {
       onUndo={() => undoMovement(port)}
       onConfirmReset={handleConfirmReset}
       onEndMatch={handleEndMatch}
+      onCalculateRonScore={(mode, han, fu) =>
+        calculateRonScore(mode, han, fu)?.total ?? null
+      }
+      onCalculateTsumoScore={(mode, han, fu) =>
+        calculateTsumoScore(mode, han, fu)?.total ?? null
+      }
+      onIncrementHonba={incrementHonba}
+      onDecrementHonba={decrementHonba}
+      onResetHonba={resetHonba}
     />
   );
 };

--- a/src/presentation/layout/DashboardLayout.tsx
+++ b/src/presentation/layout/DashboardLayout.tsx
@@ -2,17 +2,20 @@ import type { ComponentProps } from 'react';
 import { RotateCcw, LogOut } from 'lucide-react';
 import type { Player, PlayerId } from '../../domain/player';
 import type { ScoreMovement } from '../../domain/movement';
+import type { NaturalNumber } from '../../domain/natural-number';
 import { PlayerCard } from '../component/PlayerCard';
 import { ActionBar } from '../component/ActionBar';
 import { TopBarButton } from '../component/TopBarButton';
-import { RonDialog } from '../dialogs/RonDialog';
-import { TsumoDialog } from '../dialogs/TsumoDialog';
+import { RonDialog } from '../component/dialogs/RonDialog';
+import { TsumoDialog } from '../component/dialogs/TsumoDialog';
 import { RyukyokuDialog } from '../component/dialogs/RyukyokuDialog';
 import { RiichiDialog } from '../component/dialogs/RiichiDialog';
 import { ResetDialog } from '../component/dialogs/ResetDialog';
 import { EndMatchDialog } from '../component/dialogs/EndMatchDialog';
 
 export type DialogKind = 'ron' | 'tsumo' | 'ryukyoku' | 'riichi' | 'reset' | 'endMatch' | null;
+
+type WinnerMode = 'ko' | 'oya';
 
 type Props = Readonly<{
   players: ReadonlyArray<Player>;
@@ -24,6 +27,11 @@ type Props = Readonly<{
   onUndo: () => void;
   onConfirmReset: () => void;
   onEndMatch: () => void;
+  onCalculateRonScore: (mode: WinnerMode, han: number | null, fu: number | null) => number | null;
+  onCalculateTsumoScore: (mode: WinnerMode, han: number | null, fu: number | null) => number | null;
+  onIncrementHonba: (current: NaturalNumber) => NaturalNumber;
+  onDecrementHonba: (current: NaturalNumber) => NaturalNumber;
+  onResetHonba: () => NaturalNumber;
 }>;
 
 /**
@@ -40,6 +48,11 @@ export const DashboardLayout = ({
   onUndo,
   onConfirmReset,
   onEndMatch,
+  onCalculateRonScore,
+  onCalculateTsumoScore,
+  onIncrementHonba,
+  onDecrementHonba,
+  onResetHonba,
 }: Props) => (
   <div className="flex h-full flex-col bg-neutral-950 p-6">
     <div className="flex justify-end gap-3">
@@ -83,6 +96,10 @@ export const DashboardLayout = ({
         players={players}
         onConfirm={onDispatch}
         onCancel={() => onOpenDialog(null)}
+        onCalculateScore={onCalculateRonScore}
+        onIncrementHonba={onIncrementHonba}
+        onDecrementHonba={onDecrementHonba}
+        onResetHonba={onResetHonba}
       />
     )}
     {dialog === 'tsumo' && (
@@ -90,6 +107,10 @@ export const DashboardLayout = ({
         players={players}
         onConfirm={onDispatch}
         onCancel={() => onOpenDialog(null)}
+        onCalculateScore={onCalculateTsumoScore}
+        onIncrementHonba={onIncrementHonba}
+        onDecrementHonba={onDecrementHonba}
+        onResetHonba={onResetHonba}
       />
     )}
     {dialog === 'ryukyoku' && (

--- a/src/usecase/game/adjust-honba.test.ts
+++ b/src/usecase/game/adjust-honba.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { NaturalNumber } from '../../domain/natural-number';
+import { incrementHonba, decrementHonba, resetHonba } from './adjust-honba';
+
+describe('incrementHonba', () => {
+  it('0 なら 1 を返す', () => {
+    expect(incrementHonba(NaturalNumber.of(0))).toBe(1);
+  });
+
+  it('2 なら 3 を返す', () => {
+    expect(incrementHonba(NaturalNumber.of(2))).toBe(3);
+  });
+});
+
+describe('decrementHonba', () => {
+  it('2 なら 1 を返す', () => {
+    expect(decrementHonba(NaturalNumber.of(2))).toBe(1);
+  });
+
+  it('0 なら 0 のまま (下限)', () => {
+    expect(decrementHonba(NaturalNumber.of(0))).toBe(0);
+  });
+});
+
+describe('resetHonba', () => {
+  it('0 を返す', () => {
+    expect(resetHonba()).toBe(0);
+  });
+});

--- a/src/usecase/game/adjust-honba.ts
+++ b/src/usecase/game/adjust-honba.ts
@@ -1,0 +1,22 @@
+import { NaturalNumber } from '../../domain/natural-number';
+
+/**
+ * 本場カウンタを 1 増やす。
+ *
+ * @param current 現在の本場数。
+ */
+export const incrementHonba = (current: NaturalNumber): NaturalNumber =>
+  NaturalNumber.of(current + 1);
+
+/**
+ * 本場カウンタを 1 減らす。0 を下回らない。
+ *
+ * @param current 現在の本場数。
+ */
+export const decrementHonba = (current: NaturalNumber): NaturalNumber =>
+  NaturalNumber.of(Math.max(0, current - 1));
+
+/**
+ * 本場カウンタを 0 にリセットする。
+ */
+export const resetHonba = (): NaturalNumber => NaturalNumber.of(0);

--- a/src/usecase/game/calculate-ron-score.test.ts
+++ b/src/usecase/game/calculate-ron-score.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { calcKoRon, calcOyaRon } from '../../domain/score-calculation';
+import { calculateRonScore } from './calculate-ron-score';
+
+describe('calculateRonScore', () => {
+  it('han が null なら null を返す', () => {
+    expect(calculateRonScore('ko', null, 30)).toBeNull();
+  });
+
+  it('fu が null なら null を返す', () => {
+    expect(calculateRonScore('ko', 3, null)).toBeNull();
+  });
+
+  it("mode が 'ko' なら calcKoRon(han, fu) と一致する", () => {
+    expect(calculateRonScore('ko', 3, 30)).toEqual(calcKoRon(3, 30));
+  });
+
+  it("mode が 'oya' なら calcOyaRon(han, fu) と一致する", () => {
+    expect(calculateRonScore('oya', 3, 30)).toEqual(calcOyaRon(3, 30));
+  });
+});

--- a/src/usecase/game/calculate-ron-score.ts
+++ b/src/usecase/game/calculate-ron-score.ts
@@ -1,0 +1,24 @@
+import { calcKoRon, calcOyaRon } from '../../domain/score-calculation';
+import type { RonScore } from '../../domain/score-calculation';
+
+/**
+ * ロン/ツモの子・親区分。
+ */
+export type WinnerMode = 'ko' | 'oya';
+
+/**
+ * 翻・符からロンの点数を算出する。
+ *
+ * @param mode 和了者の子/親区分。
+ * @param han 翻数。未選択の場合は null。
+ * @param fu 符数。未選択の場合は null。
+ * @returns 算出された点数。han または fu が未選択の場合は null。
+ */
+export const calculateRonScore = (
+  mode: WinnerMode,
+  han: number | null,
+  fu: number | null,
+): RonScore | null => {
+  if (han === null || fu === null) return null;
+  return mode === 'ko' ? calcKoRon(han, fu) : calcOyaRon(han, fu);
+};

--- a/src/usecase/game/calculate-tsumo-score.test.ts
+++ b/src/usecase/game/calculate-tsumo-score.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { calcKoTsumo, calcOyaTsumo } from '../../domain/score-calculation';
+import { calculateTsumoScore } from './calculate-tsumo-score';
+
+describe('calculateTsumoScore', () => {
+  it('han が null なら null を返す', () => {
+    expect(calculateTsumoScore('ko', null, 30)).toBeNull();
+  });
+
+  it('fu が null なら null を返す', () => {
+    expect(calculateTsumoScore('ko', 3, null)).toBeNull();
+  });
+
+  it("mode が 'ko' なら calcKoTsumo(han, fu) と一致する", () => {
+    expect(calculateTsumoScore('ko', 3, 30)).toEqual(calcKoTsumo(3, 30));
+  });
+
+  it("mode が 'oya' なら calcOyaTsumo(han, fu) と一致する", () => {
+    expect(calculateTsumoScore('oya', 3, 30)).toEqual(calcOyaTsumo(3, 30));
+  });
+});

--- a/src/usecase/game/calculate-tsumo-score.ts
+++ b/src/usecase/game/calculate-tsumo-score.ts
@@ -1,0 +1,20 @@
+import { calcKoTsumo, calcOyaTsumo } from '../../domain/score-calculation';
+import type { TsumoKoScore, TsumoOyaScore } from '../../domain/score-calculation';
+import type { WinnerMode } from './calculate-ron-score';
+
+/**
+ * 翻・符からツモの点数を算出する。
+ *
+ * @param mode 和了者の子/親区分。
+ * @param han 翻数。未選択の場合は null。
+ * @param fu 符数。未選択の場合は null。
+ * @returns 算出された点数。han または fu が未選択の場合は null。
+ */
+export const calculateTsumoScore = (
+  mode: WinnerMode,
+  han: number | null,
+  fu: number | null,
+): TsumoKoScore | TsumoOyaScore | null => {
+  if (han === null || fu === null) return null;
+  return mode === 'ko' ? calcKoTsumo(han, fu) : calcOyaTsumo(han, fu);
+};


### PR DESCRIPTION
## 概要

- RonDialog / TsumoDialog に残っていた domain への runtime 依存 (点数計算・本場カウンタ) を usecase 層の action へ移設した。
- 両ダイアログを `component/dialogs/` へ移動し、presentation 配下の旧 `dialogs/` ディレクトリを解消した。

Closes #59

> [!NOTE]
> このブランチは #58 (PR #65) の上に積んだスタック PR です。下位 PR のマージ後に base が順に付け替わります。レビュー対象はコミット 615e3da のみです。

## 背景

- #58 の完了時点で、component 未移行のダイアログは Ron/Tsumo の 2 件だけになっていた。
- この 2 件は `calcKoRon` 等の domain 関数と `NaturalNumber` (値) を直接 import しており、「component は domain の値を知らない」という親 Issue #54 の依存規約への最後の違反箇所だった。

## 課題

翻/符から点数を算出するプレビューと本場カウンタの増減が component 内に埋まっており、テスト不能かつ依存規約違反の状態だった。

## 目標

### 必須項目

- 点数プレビューと本場操作を usecase の純粋関数にし、Vitest でテストする
- 両ダイアログの domain runtime import を 0 件にする (type-only のみ残す)
- 点数プレビュー・本場カウンタ・確定 movement の値は現行と完全に同一

### 範囲外

- ドキュメント更新と依存境界の最終検証 (#61)

## 採用手法

usecase は domain の score 型 (`RonScore` 等) を返し、container が `.total ?? null` で数値へ変換して component へ渡す。component の props は `onCalculateScore: (mode, han, fu) => number | null` という数値契約だけになり、domain の型構造から完全に独立する。本場カウンタは `incrementHonba` / `decrementHonba` (0 下限) / `resetHonba` を props で受け取り、`useState<NaturalNumber>(onResetHonba)` の lazy initializer で初期値も usecase 経由にした。

### 検討した選択肢

| 選択肢 | 長所 | 短所 |
|--------|------|------|
| A: usecase は domain 型を返し、container が total へ変換 (採用) | usecase が domain に忠実 (内訳情報を失わない)。component は数値のみ知る | container に変換 1 行が増える |
| B: usecase が最初から number \| null を返す | 変換不要 | ツモの子/親別支払い内訳など domain が持つ情報を usecase 境界で捨てることになり、将来内訳表示を追加する際に usecase の契約変更が要る |
| C: ダイアログが usecase を直接 import | props が減る | component → usecase の依存が生まれ、受入基準 (component の usecase import 0 件) に違反 |

### 採用理由

A は「domain に忠実な usecase」と「数値しか知らない component」を 1 行の変換で両立し、受入基準の grep 検証をすべて満たす唯一の構成だった。

## 変更箇所

- `src/usecase/game/calculate-ron-score.ts`: `WinnerMode` 型と `calculateRonScore` (翻/符未選択は null) + テスト
- `src/usecase/game/calculate-tsumo-score.ts`: `calculateTsumoScore` (ko/oya 分岐) + テスト
- `src/usecase/game/adjust-honba.ts`: `incrementHonba` / `decrementHonba` (0 下限) / `resetHonba` + テスト
- `src/presentation/component/dialogs/RonDialog.tsx` / `TsumoDialog.tsx`: 移動 + domain 値 import 除去 + props 化 (JSX・表示は無変更)
- `src/presentation/container/DashboardContainer.tsx`: usecase action を束ねた callback 5 本を配線
- `src/presentation/layout/DashboardLayout.tsx`: import 先更新と新 props の橋渡し

## 妥協と制限

- **DashboardContainer の認知的複雑度が 4.37 → 6.10 に増加**: callback 配線 5 本の追加による機能増分で、同一機能での構造悪化ではない (コードベース最大値 24.38 から十分低い)。削れる構造重複はないと判断した
- **ダイアログのフック挙動の自動テストなし**: Testing Library 未導入のため。算出ロジックは usecase テスト 13 件で担保し、手動回帰は #61 で実施

## 検証方法

- `nix develop -c pnpm test` — 99 テスト全パス (新規 13 件: null ガード・domain 関数一致・honba 下限)
- `nix develop -c pnpm run typecheck` / `pnpm run build` — 成功
- `grep -rn "from '.*domain/" src/presentation/component | grep -v "import type"` — 0 件 (Ron/Tsumo 含む全 component で達成)
- `grep -rn "from '.*usecase/" src/presentation/component src/presentation/layout` — 0 件
- 旧 `src/presentation/dialogs/` が存在しないことを確認

## 確認事項

- ⚠️ component への契約を「total の数値のみ」とした (選択肢 A)。将来ツモの支払い内訳をダイアログに表示する場合は props の契約拡張が必要になる
- ⚠️ `WinnerMode` 型は producer の `calculate-ron-score.ts` が所有し tsumo 側が import している (`rank-standings.ts` が `RankedPlayer` を所有するのと同じパターン)

## 参考文献

- [#59 RonDialog/TsumoDialog の点数プレビュー・本場カウンタの usecase 化](https://github.com/shunsock/mahjong_meetup/issues/59)
- [#54 presentation 層を clean architecture 4 階層 + usecase 層へ再編する](https://github.com/shunsock/mahjong_meetup/issues/54)
- [PR #65 controls と単純ダイアログの component 移行](https://github.com/shunsock/mahjong_meetup/pull/65) (スタック元)
