### PR TITLE
docs: レイヤー構成を 4 階層の最終形へ更新し依存境界を検証する

### DIFF
--- a/docs/develop.md
+++ b/docs/develop.md
@@ -4,14 +4,22 @@
 
 ```
 src/
-├── domain/          # ドメインロジック (純粋関数・値オブジェクト)
-├── usecase/         # アプリケーションのビジネスフローと外部依存の抽象 (Port)
-├── adapter/         # usecase の Port の実装 (React hooks 等)
-├── presentation/    # UI コンポーネント
-│   ├── controls/    # 入力系コンポーネント
-│   └── dialogs/     # ダイアログコンポーネント
-├── main.tsx         # エントリーポイント
-└── index.css        # グローバルスタイル
+├── domain/               # ドメインロジック (純粋関数・値オブジェクト)
+├── usecase/              # アプリケーションのビジネスフローと外部依存の抽象 (Port)
+│   ├── game/             # 対局中の action と GameStatePort
+│   ├── setup/            # セットアップ画面の action
+│   └── result/           # 結果画面の action
+├── adapter/
+│   └── state/            # usecase の Port の実装 (React hooks 等)
+├── presentation/
+│   ├── screen/           # 画面のエントリーポイント (container の composition)
+│   ├── container/        # 状態と effect を持ち usecase の action を起動する
+│   ├── layout/           # 状態を持たない純粋な JSX 配置
+│   └── component/        # 末端の UI 部品
+│       ├── controls/     # 入力系コンポーネント
+│       └── dialogs/      # ダイアログコンポーネント
+├── main.tsx              # エントリーポイント
+└── index.css             # グローバルスタイル
 ```
 
 ### 各レイヤーの責務
@@ -21,9 +29,24 @@ src/
 | `domain` | 点数計算・スコアボード等のビジネスロジック。フレームワーク非依存 | なし |
 | `usecase` | `domain` を使ったアプリケーションのビジネスフロー (action) と、状態操作等の外部依存を抽象化する Port | `domain` |
 | `adapter` | `usecase` の Port を実装する具体的な手段 (React hooks 等) | `domain`, `usecase` |
-| `presentation` | 画面表示とユーザー操作のハンドリング | `domain`, `usecase`, `adapter` |
+| `presentation/screen` | 画面のエントリーポイント。`container` を composition するだけ | `container` |
+| `presentation/container` | 状態と effect を持ち、`usecase` の action を起動して結果を UI へ適用する | `usecase`, `adapter`, `layout`, `domain` (型のみ) |
+| `presentation/layout` | 状態を持たない純粋な JSX 配置 | `component`, `domain` (型のみ) |
+| `presentation/component` | 末端の UI 部品。props のみに依存する | `domain` (型のみ) |
 
-依存方向は `presentation` → `usecase` / `adapter` → `domain` の一方向です。`domain` は他のレイヤーに依存しません。`adapter` は `usecase` が定義する Port を実装する形で依存します。
+依存方向は次の 2 系統です。
+
+- UI: `screen` → `container` → `layout` → `component`
+- レイヤー: `container` → `usecase` → `domain` (usecase の Port を `adapter` が実装)
+
+`component` / `layout` から `domain` への依存は import type に限ります。
+
+画面内のイベントは次の順で流れます。
+
+1. `component` のイベントハンドラが発火する
+2. `container` の effect が受け取り、`usecase` の action を呼び出す
+3. action は DI された `adapter` (Port 実装) を通じて状態を更新する
+4. コールバック経由で `container` の状態が UI へ反映される
 
 ## コマンド一覧
 
@@ -51,7 +74,7 @@ nix develop -c pnpm run preview
 
 ## テスト
 
-テストは `domain` レイヤーに対して書かれています。`*.test.ts` ファイルが対応するモジュールと同じディレクトリに配置されています。
+テストは `domain` と `usecase` レイヤーに対して書かれています。`*.test.ts` ファイルが対応するモジュールと同じディレクトリに配置されています。
 
 ```bash
 # 全テスト実行
@@ -66,7 +89,8 @@ nix develop -c pnpm run vitest run src/domain/scoreboard.test.ts
 - **不変データ**: ドメインオブジェクトは immutable。状態の変更は新しいオブジェクトを生成して行う
 - **純粋関数**: `domain` レイヤーは副作用を持たない純粋関数で構成する
 - **型安全**: `NaturalNumber` 等の値オブジェクトで不正な状態を型レベルで防止する
-- **一方向依存**: `presentation` → `usecase` / `adapter` → `domain` の依存方向を守る
+- **一方向依存 (UI)**: `screen` → `container` → `layout` → `component` の方向を守る
+- **一方向依存 (レイヤー)**: `container` → `usecase` / `adapter` → `domain` の方向を守る
 
 ## CI
 


### PR DESCRIPTION
## 概要

- clean architecture 再編 (#54) の最終サブイシューとして、docs/develop.md を 4 階層の最終形へ更新した。
- 依存境界の最終検証 (grep 5 種) を実施し、すべて違反 0 件であることを確認した。

Closes #61

> [!NOTE]
> このブランチは #60 (PR #67) の上に積んだスタック PR で、#55〜#60 のスタックの最上段です。下位 PR のマージ後に base が順に付け替わります。レビュー対象はコミット ab9ad43 のみです。

## 背景

- #55〜#60 で骨組み・3 画面・全ダイアログの移行が完了し、src 構成は親 Issue #54 の目標形に到達した。
- docs/develop.md は #55 時点の暫定更新 (3 レイヤー表記) のままで、presentation の 4 階層が未記載だった。

## 課題

ドキュメントが実装より古く、新しい依存ルール (screen → container → layout → component、component/layout の domain 依存は import type のみ) が明文化されていなかった。

## 目標

### 必須項目

- docs/develop.md の構成ツリー・レイヤー表・依存方向・イベントフロー・テスト節を実態と一致させる
- 依存境界の最終検証を grep で実施し結果を記録する

### 範囲外

- 新規機能追加、UI テスト基盤 (React Testing Library) の導入

## 変更箇所

- `docs/develop.md`: 構成ツリーを usecase (game/setup/result)・adapter・presentation 4 階層に更新。レイヤー表を 7 行に拡張し、依存方向 2 系統・イベントフロー 4 段・設計方針を明文化。textlint (ja-technical-writing) の指摘 3 件は箇条書き化で解消済み

## 検証方法 (依存境界の最終検証)

以下の 5 検証をすべて実行し、違反 0 件を確認した。

- `grep -rn "from '.*domain/" src/presentation/component | grep -v "import type"` — 0 件
- `grep -rn "from '.*usecase/" src/presentation/component src/presentation/layout` — 0 件
- `grep -rn "from '.*presentation" src/usecase` — 0 件
- `grep -rn "from '.*presentation" src/adapter` — 0 件
- `src/domain` から外層への import — 0 件

あわせて `nix develop -c pnpm run typecheck` / `pnpm test` (103 件) / `pnpm run build` の全パスを確認した。

## 妥協と制限

- **手動回帰確認は未実施**: 対局設定 → リーチ/ロン/ツモ/流局 → Undo → 対戦終了 → 最終得点表示の一連の目視確認は、バックグラウンド実行環境では実施できない。下記チェックリストをマージ前に `nix develop -c pnpm dev` で実施してほしい
  - [ ] 4 人の名前入力で開始ボタンが活性化し、ウマ・返し点設定が反映される
  - [ ] リーチ/ロン/ツモ/流局の各ダイアログで持ち点・順位・点差が正しく変化する
  - [ ] ロン/ツモの翻符選択で点数プレビューが表示され、本場カウンタが増減する
  - [ ] Undo で直前操作が取り消される
  - [ ] 対戦終了で最終得点 (ウマ・返し反映) が表示され、トップに戻れる

## 確認事項

- ⚠️ 上記の手動回帰チェックリストの実施をマージ条件とするかはレビュアーの判断に委ねる (コード上の検証はすべて green)

## 参考文献

- [#61 ドキュメント更新と依存境界の最終検証](https://github.com/shunsock/mahjong_meetup/issues/61)
- [#54 presentation 層を clean architecture 4 階層 + usecase 層へ再編する](https://github.com/shunsock/mahjong_meetup/issues/54)
- [PR #67 ResultScreen の 4 層移行](https://github.com/shunsock/mahjong_meetup/pull/67) (スタック元)
